### PR TITLE
Allow sidecar to stop without nice deregister on second signal

### DIFF
--- a/cmd/katalog-sync-sidecar/main.go
+++ b/cmd/katalog-sync-sidecar/main.go
@@ -104,8 +104,18 @@ WAITLOOP:
 		}
 	}
 
+	go func() {
+		<-sigs
+		cancel()
+	}()
+
 	// Send deregister request
 	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
 		logrus.Infof("deregister attempt")
 		_, err := client.Deregister(ctx, &katalogsync.DeregisterQuery{Namespace: opts.Namespace, PodName: opts.PodName, ContainerName: opts.ContainerName})
 		if err == nil {

--- a/cmd/katalog-sync-sidecar/main.go
+++ b/cmd/katalog-sync-sidecar/main.go
@@ -15,7 +15,6 @@ import (
 	katalogsync "github.com/wish/katalog-sync/proto"
 )
 
-// TODO: consul flags
 var opts struct {
 	LogLevel            string `long:"log-level" description:"Log level" default:"info"`
 	KatalogSyncEndpoint string `long:"katalog-sync-daemon" description:"katalog-sync-daemon API endpoint"`


### PR DESCRIPTION
Mostly useful for local ctrl-c testing