### PR TITLE
Catalog check

### DIFF
--- a/cmd/katalog-sync-daemon/main.go
+++ b/cmd/katalog-sync-daemon/main.go
@@ -57,7 +57,7 @@ func main() {
 		panic(err)
 	}
 
-	d := daemon.NewDaemon(opts.DaemonConfig, kubeletClient, client.Agent())
+	d := daemon.NewDaemon(opts.DaemonConfig, kubeletClient, client)
 
 	if opts.BindAddr != "" {
 		s := grpc.NewServer()

--- a/pkg/daemon/interface.go
+++ b/pkg/daemon/interface.go
@@ -9,6 +9,10 @@ type Kubelet interface {
 	GetPodList() (*k8sApi.PodList, error)
 }
 
+type ConsulCatalog interface {
+	Services() (map[string]*consulApi.AgentService, error)
+}
+
 type ConsulAgent interface {
 	UpdateTTL(checkID, output, status string) error
 	Services() (map[string]*consulApi.AgentService, error)


### PR DESCRIPTION
When the sidecar wants to register/deregister we'll additionally check that the service has propagated from the local agent to the catalog API. This way if there are any issues with the local agent syncing with the remote cluster we'll consider ourselves not synced.