### PR TITLE
Better support for services with initialDelaySeconds ready checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,6 @@ katalog-sync has:
 katalog-sync does this by making a few assumptions:
 
 - You have a consul-agent running on each node (presumably as a Daemonset)
+- You are running a consul-agent which supports ServiceMetadata (>= [1.0.7](https://www.hashicorp.com/blog/consul-1-0-7))
 - You want to sync Pods to consul services and have the readiness values reflected
 - Your pods can communicate with Daemonsets running on the same node

--- a/cmd/katalog-sync-daemon/main.go
+++ b/cmd/katalog-sync-daemon/main.go
@@ -17,9 +17,9 @@ import (
 
 // TODO: consul flags
 var opts struct {
-	LogLevel      string `long:"log-level" description:"Log level" default:"info"`
-	BindAddr      string `long:"bind-address" description:"address for binding RPC interface for sidecar"`
-	PProfBindAddr string `long:"pprof-bind-address" description:"address for binding pprof"`
+	LogLevel      string `long:"log-level" env:"LOG_LEVEL" description:"Log level" default:"info"`
+	BindAddr      string `long:"bind-address" env:"BIND_ADDRESS" description:"address for binding RPC interface for sidecar"`
+	PProfBindAddr string `long:"pprof-bind-address" env:"PPROF_BIND_ADDRESS" description:"address for binding pprof"`
 	daemon.DaemonConfig
 	daemon.KubeletClientConfig
 }

--- a/cmd/katalog-sync-sidecar/main.go
+++ b/cmd/katalog-sync-sidecar/main.go
@@ -17,9 +17,10 @@ import (
 )
 
 var opts struct {
-	LogLevel            string `long:"log-level" env:"LOG_LEVEL" description:"Log level" default:"info"`
-	KatalogSyncEndpoint string `long:"katalog-sync-daemon" env:"KATALOG_SYNC_DAEMON" description:"katalog-sync-daemon API endpoint"`
-	BindAddr            string `long:"bind-address" env:"BIND_ADDRESS" description:"address for binding checks to"`
+	LogLevel              string        `long:"log-level" env:"LOG_LEVEL" description:"Log level" default:"info"`
+	KatalogSyncEndpoint   string        `long:"katalog-sync-daemon" env:"KATALOG_SYNC_DAEMON" description:"katalog-sync-daemon API endpoint"`
+	KatalogSyncMaxBackoff time.Duration `long:"katalog-sync-daemon-max-backoff" env:"KATALOG_SYNC_DAEMON_MAX_BACKOFF" description:"katalog-sync-daemon API max backoff" default:"1s"`
+	BindAddr              string        `long:"bind-address" env:"BIND_ADDRESS" description:"address for binding checks to"`
 
 	Namespace     string `long:"namespace" env:"NAMESPACE" description:"k8s namespace this is running in"`
 	PodName       string `long:"pod-name" env:"POD_NAME" description:"k8s pod this is running in"`
@@ -68,7 +69,7 @@ func main() {
 		http.Serve(l, http.DefaultServeMux)
 	}()
 
-	conn, err := grpc.Dial(opts.KatalogSyncEndpoint, grpc.WithInsecure())
+	conn, err := grpc.Dial(opts.KatalogSyncEndpoint, grpc.WithInsecure(), grpc.WithBackoffMaxDelay(opts.KatalogSyncMaxBackoff))
 	if err != nil {
 		logrus.Fatalf("Unable to connect to katalog-sync-daemon: %v", err)
 	}

--- a/cmd/katalog-sync-sidecar/main.go
+++ b/cmd/katalog-sync-sidecar/main.go
@@ -141,5 +141,8 @@ WAITLOOP:
 		if err == nil {
 			return
 		}
+
+		// TODO: better sleep + backoff based on GRPC error codes
+		time.Sleep(time.Second)
 	}
 }

--- a/cmd/katalog-sync-sidecar/main.go
+++ b/cmd/katalog-sync-sidecar/main.go
@@ -17,13 +17,13 @@ import (
 )
 
 var opts struct {
-	LogLevel            string `long:"log-level" description:"Log level" default:"info"`
-	KatalogSyncEndpoint string `long:"katalog-sync-daemon" description:"katalog-sync-daemon API endpoint"`
-	BindAddr            string `long:"bind-address" description:"address for binding checks to"`
+	LogLevel            string `long:"log-level" env:"LOG_LEVEL" description:"Log level" default:"info"`
+	KatalogSyncEndpoint string `long:"katalog-sync-daemon" env:"KATALOG_SYNC_DAEMON" description:"katalog-sync-daemon API endpoint"`
+	BindAddr            string `long:"bind-address" env:"BIND_ADDRESS" description:"address for binding checks to"`
 
-	Namespace     string `long:"namespace"`
-	PodName       string `long:"pod-name"`
-	ContainerName string `long:"container-name"`
+	Namespace     string `long:"namespace" env:"NAMESPACE" description:"k8s namespace this is running in"`
+	PodName       string `long:"pod-name" env:"POD_NAME" description:"k8s pod this is running in"`
+	ContainerName string `long:"container-name" env:"CONTAINER_NAME" description:"k8s container this is running in"`
 }
 
 func main() {

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -21,11 +21,11 @@ var (
 
 // DaemonConfig contains the configuration options for a katalog-sync-daemon
 type DaemonConfig struct {
-	MinSyncInterval     time.Duration `long:"min-sync-interval" description:"minimum duration allowed for sync" default:"500ms"`
-	MaxSyncInterval     time.Duration `long:"max-sync-interval" description:"maximum duration allowed for sync" default:"5s"`
-	DefaultSyncInterval time.Duration `long:"default-sync-interval" default:"1s"`
-	DefaultCheckTTL     time.Duration `long:"default-check-ttl" default:"10s"`
-	SyncTTLBuffer       time.Duration `long:"sync-ttl-buffer-duration" description:"how much time to ensure is between sync time and ttl" default:"10s"`
+	MinSyncInterval     time.Duration `long:"min-sync-interval" env:"MIN_SYNC_INTERVAL" description:"minimum duration allowed for sync" default:"500ms"`
+	MaxSyncInterval     time.Duration `long:"max-sync-interval" env:"MAX_SYNC_INTERVAL" description:"maximum duration allowed for sync" default:"5s"`
+	DefaultSyncInterval time.Duration `long:"default-sync-interval" env:"DEFAULT_SYNC_INTERVAL" default:"1s"`
+	DefaultCheckTTL     time.Duration `long:"default-check-ttl" env:"DEFAULT_CHECK_TTL" default:"10s"`
+	SyncTTLBuffer       time.Duration `long:"sync-ttl-buffer-duration" env:"SYNC_TTL_BUFFER_DURATION" description:"how much time to ensure is between sync time and ttl" default:"10s"`
 }
 
 // NewDaemon is a helper function to return a new *Daemon

--- a/pkg/daemon/k8s.go
+++ b/pkg/daemon/k8s.go
@@ -12,8 +12,8 @@ import (
 
 // KubeletClientConfig holds the config options for connecting to the kubelet API
 type KubeletClientConfig struct {
-	APIEndpoint        string `long:"kubelet-api" description:"kubelet API endpoint" default:"http://localhost:10255/pods"`
-	InsecureSkipVerify bool   `long:"kubelet-api-insecure-skip-verify" description:"skip verification of TLS certificate from kubelet API"`
+	APIEndpoint        string `long:"kubelet-api" env:"KUBELET_API" description:"kubelet API endpoint" default:"http://localhost:10255/pods"`
+	InsecureSkipVerify bool   `long:"kubelet-api-insecure-skip-verify" env:"KUBELET_API_INSECURE_SKIP_VERIFY" description:"skip verification of TLS certificate from kubelet API"`
 }
 
 // NewKubeletClient returns a new KubeletClient based on the given config


### PR DESCRIPTION
Before the sidecar would immediately do a sync and check the ready state. If the pod wasn't ready at that moment then the sidecar would die, which would tear down the pod. If you have a service which takes some time to be ready this is less-than-desirable. As a simple solution to this the sidecar will now retry indefinitely (until killed) to sync the service with consul. This keeps the katalog-sync code simple and allows the user to control the timing etc. through k8s configuration of the readiness.