### PR TITLE
Add support for ServiceMeta

### DIFF
--- a/config/example_sidecar.yaml
+++ b/config/example_sidecar.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: hw
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       app: hw
@@ -20,6 +20,8 @@ spec:
         katalog-sync.wish.com/service-names: hw-service-name,servicename2
         katalog-sync.wish.com/service-port: '8080'
         katalog-sync.wish.com/service-port-servicename2: '12345'
+        katalog-sync.wish.com/service-meta: 'a:1,b:2'
+        katalog-sync.wish.com/service-meta-servicename2: 'b:1,c:2'
         katalog-sync.wish.com/service-tags: a,b
         katalog-sync.wish.com/sync-interval: 2s
     spec:

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -318,8 +318,7 @@ func (d *Daemon) syncConsul() error {
 			} else {
 				// Define the base metadata that katalog-sync requires
 				meta := map[string]string{
-					"external-source":    "kubernetes",             // TODO: make this configurable?
-					"external-k8s-ns":    pod.ObjectMeta.Namespace, /// Lets put in what NS this came from
+					"external-source":    "kubernetes",             // Define the source of this service; see https://github.com/hashicorp/consul/blob/fc1d9e5d78749edc55249e5e7c1a8f7a24add99d/website/source/docs/platform/k8s/service-sync.html.md#service-meta
 					ConsulSyncSourceName: ConsulSyncSourceValue,    // Mark this as katalog-sync so we know we generated this
 					ConsulK8sLinkName:    pod.ObjectMeta.SelfLink,  // which includes full path to this (ns, pod name, etc.)
 				}

--- a/pkg/daemon/struct.go
+++ b/pkg/daemon/struct.go
@@ -18,6 +18,8 @@ var (
 	ConsulServicePortOverride = "katalog-sync.wish.com/service-port-"     // port override to use for a specific service name
 	ConsulServiceTags         = "katalog-sync.wish.com/service-tags"      // tags for the service
 	ConsulServiceTagsOverride = "katalog-sync.wish.com/service-tags-"     // tags override to use for a specific service name
+	ConsulServiceMeta         = "katalog-sync.wish.com/service-meta"      // meta for the service
+	ConsulServiceMetaOverride = "katalog-sync.wish.com/service-meta-"     // meta override to use for a specific service name
 	SidecarName               = "katalog-sync.wish.com/sidecar"           // Name of sidecar container, only to be set if it exists
 	SyncInterval              = "katalog-sync.wish.com/sync-interval"     // How frequently we want to sync this service
 	ConsulServiceCheckTTL     = "katalog-sync.wish.com/service-check-ttl" // TTL for the service checks we put in consul
@@ -140,6 +142,19 @@ func (p *Pod) GetTags(n string) []string {
 	}
 
 	return strings.Split(p.Pod.ObjectMeta.Annotations[ConsulServiceTags], ",")
+}
+
+// GetServiceMeta returns a map of metadata to be added to the ServiceMetadata
+func (p *Pod) GetServiceMeta(n string) map[string]string {
+	if metaStr, ok := p.Pod.ObjectMeta.Annotations[ConsulServiceMetaOverride+n]; ok {
+		return ParseMap(metaStr)
+	}
+
+	if metaStr, ok := p.Pod.ObjectMeta.Annotations[ConsulServiceMeta]; ok {
+		return ParseMap(metaStr)
+	}
+
+	return nil
 }
 
 // GetPort returns the port for a given service for this pod

--- a/pkg/daemon/struct_test.go
+++ b/pkg/daemon/struct_test.go
@@ -16,12 +16,13 @@ import (
 var podTestDir = "testfiles"
 
 type podTestResult struct {
-	Err          bool                       `json:"error"`
-	ServiceNames []string                   `json:"service_names"`
-	ServiceIDs   map[string]string          `json:"service_ids"`
-	Tags         map[string][]string        `json:"tags"`
-	Ports        map[string]int             `json:"ports"`
-	Ready        map[string]map[string]bool `json:"ready"`
+	Err          bool                         `json:"error"`
+	ServiceNames []string                     `json:"service_names"`
+	ServiceIDs   map[string]string            `json:"service_ids"`
+	Tags         map[string][]string          `json:"tags"`
+	Ports        map[string]int               `json:"ports"`
+	Ready        map[string]map[string]bool   `json:"ready"`
+	ServiceMeta  map[string]map[string]string `json:"service_meta"`
 }
 
 func TestPod(t *testing.T) {
@@ -69,10 +70,11 @@ func runPodIntegrationTest(t *testing.T, testDir string) {
 
 		t.Run(relFilePath, func(t *testing.T) {
 			result := &podTestResult{
-				ServiceIDs: make(map[string]string),
-				Tags:       make(map[string][]string),
-				Ports:      make(map[string]int),
-				Ready:      make(map[string]map[string]bool),
+				ServiceIDs:  make(map[string]string),
+				Tags:        make(map[string][]string),
+				Ports:       make(map[string]int),
+				Ready:       make(map[string]map[string]bool),
+				ServiceMeta: make(map[string]map[string]string),
 			}
 
 			pod, err := NewPod(k8sPod, &DaemonConfig{})
@@ -86,6 +88,7 @@ func runPodIntegrationTest(t *testing.T, testDir string) {
 					result.Tags[name] = pod.GetTags(name)
 					result.Ports[name] = pod.GetPort(name)
 					_, result.Ready[name] = pod.Ready()
+					result.ServiceMeta[name] = pod.GetServiceMeta(name)
 				}
 			}
 

--- a/pkg/daemon/testfiles/basic/working/baseline.json
+++ b/pkg/daemon/testfiles/basic/working/baseline.json
@@ -29,5 +29,9 @@
     "servicename2": {
       "hw": true
     }
+  },
+  "service_meta": {
+    "hw-service-name": null,
+    "servicename2": null
   }
 }

--- a/pkg/daemon/testfiles/sidecar/bad_sidecar_name/baseline.json
+++ b/pkg/daemon/testfiles/sidecar/bad_sidecar_name/baseline.json
@@ -4,5 +4,6 @@
   "service_ids": {},
   "tags": {},
   "ports": {},
-  "ready": {}
+  "ready": {},
+  "service_meta": {}
 }

--- a/pkg/daemon/testfiles/sidecar/not_ready/baseline.json
+++ b/pkg/daemon/testfiles/sidecar/not_ready/baseline.json
@@ -25,5 +25,9 @@
   "ready": {
     "hw-service-name": null,
     "servicename2": null
+  },
+  "service_meta": {
+    "hw-service-name": null,
+    "servicename2": null
   }
 }

--- a/pkg/daemon/testfiles/sidecar/sidecar_not_ready/baseline.json
+++ b/pkg/daemon/testfiles/sidecar/sidecar_not_ready/baseline.json
@@ -25,5 +25,9 @@
   "ready": {
     "hw-service-name": null,
     "servicename2": null
+  },
+  "service_meta": {
+    "hw-service-name": null,
+    "servicename2": null
   }
 }

--- a/pkg/daemon/testfiles/sidecar/working/baseline.json
+++ b/pkg/daemon/testfiles/sidecar/working/baseline.json
@@ -29,5 +29,15 @@
     "servicename2": {
       "hw": true
     }
+  },
+  "service_meta": {
+    "hw-service-name": {
+      "a": "1",
+      "b": "2"
+    },
+    "servicename2": {
+      "b": "1",
+      "c": "2"
+    }
   }
 }

--- a/pkg/daemon/testfiles/sidecar/working/input.json
+++ b/pkg/daemon/testfiles/sidecar/working/input.json
@@ -17,6 +17,8 @@
 			"katalog-sync.wish.com/service-port-servicename2": "12345",
 			"katalog-sync.wish.com/service-tags": "a,b",
 			"katalog-sync.wish.com/service-tags-servicename2": "b,c",
+			"katalog-sync.wish.com/service-meta": "a:1,b:2",
+			"katalog-sync.wish.com/service-meta-servicename2": "b:1,c:2",
 			"katalog-sync.wish.com/sidecar": "katalog-sync-sidecar",
 			"katalog-sync.wish.com/sync-interval": "2s",
 			"kubernetes.io/config.seen": "2019-02-11T15:44:03.945239692-08:00",

--- a/pkg/daemon/util.go
+++ b/pkg/daemon/util.go
@@ -1,0 +1,17 @@
+package daemon
+
+import (
+	"strings"
+)
+
+func ParseMap(s string) map[string]string {
+	pairs := strings.Split(s, ",")
+	m := make(map[string]string, len(pairs))
+	for _, pair := range pairs {
+		split := strings.Split(pair, ":")
+		if len(split) == 2 {
+			m[strings.TrimSpace(split[0])] = strings.TrimSpace(split[1])
+		}
+	}
+	return m
+}

--- a/pkg/daemon/util_test.go
+++ b/pkg/daemon/util_test.go
@@ -1,0 +1,41 @@
+package daemon
+
+import (
+	"reflect"
+	"strconv"
+	"testing"
+)
+
+func TestParseMap(t *testing.T) {
+	tests := []struct {
+		in  string
+		out map[string]string
+	}{
+		// Basic well formed
+		{
+			in:  "a:1,b:2",
+			out: map[string]string{"a": "1", "b": "2"},
+		},
+
+		// With some spaces
+		{
+			in:  "a:1, b:2",
+			out: map[string]string{"a": "1", "b": "2"},
+		},
+
+		// With some invalid mappings
+		{
+			in:  "a:1,b",
+			out: map[string]string{"a": "1"},
+		},
+	}
+
+	for i, test := range tests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			m := ParseMap(test.in)
+			if !reflect.DeepEqual(m, test.out) {
+				t.Fatalf("Mismatch expected=%v acutal=%v", test.out, m)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This adds support for annotations for ServiceMeta to be passed through
to the consul service. NodeMeta is already effectively passed through
(as the services are agent services).

Implements #13