### PR TITLE
add an annotation to mark service health to a fixed status

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -428,7 +428,10 @@ func (d *Daemon) syncConsul() error {
 						meta[k] = v
 					}
 				}
-
+				serviceStatus := status
+				if meta[MetaAlwaysHealthy] == "true" {
+					serviceStatus = consulApi.HealthPassing
+				}
 				// Next we actually register the service with consul
 				pod.SyncStatuses.GetStatus(serviceName).SetError(d.consulClient.Agent().ServiceRegister(&consulApi.AgentServiceRegistration{
 					ID:      pod.GetServiceID(serviceName),
@@ -442,7 +445,7 @@ func (d *Daemon) syncConsul() error {
 						CheckID: pod.GetServiceID(serviceName), // TODO: better name? -- the name cannot have `/` in it -- its used in the API query path
 						TTL:     pod.CheckTTL.String(),
 
-						Status: status,         // Current status of check
+						Status: serviceStatus,         // Current status of check
 						Notes:  string(notesB), // Map of container->ready
 					},
 				}))

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"time"
 
 	consulApi "github.com/hashicorp/consul/api"
@@ -429,7 +430,7 @@ func (d *Daemon) syncConsul() error {
 					}
 				}
 				serviceStatus := status
-				if meta[MetaAlwaysHealthy] == "true" {
+				if alwaysHealthy, err := strconv.ParseBool(meta[MetaAlwaysHealthy]); err == nil && alwaysHealthy {
 					serviceStatus = consulApi.HealthPassing
 				}
 				// Next we actually register the service with consul

--- a/pkg/daemon/struct.go
+++ b/pkg/daemon/struct.go
@@ -34,6 +34,9 @@ var (
 	SyncInterval              = "katalog-sync.wish.com/sync-interval"     // How frequently we want to sync this service
 	ConsulServiceCheckTTL     = "katalog-sync.wish.com/service-check-ttl" // TTL for the service checks we put in consul
 	ContainerExclusion        = "katalog-sync.wish.com/container-exclude" // comma-separated list of containers to exclude from ready check
+
+	// Meta keys that are used as per-service flags
+	MetaAlwaysHealthy = "_always_healthy"  // always mark service as healthy in Consul
 )
 
 // NewPod returns a daemon pod based on a config and a k8s pod

--- a/pkg/daemon/struct.go
+++ b/pkg/daemon/struct.go
@@ -209,12 +209,9 @@ func (p *Pod) GetServiceHealth(n string, defaultVal string) string {
 		healthStr = p.Pod.ObjectMeta.Annotations[ConsulServiceHealth]
 	}
 	switch healthStr {
-	case consulApi.HealthCritical:
-	case consulApi.HealthPassing:
-	case consulApi.HealthWarning:
+	case consulApi.HealthCritical, consulApi.HealthPassing,  consulApi.HealthWarning:
 		return healthStr
-	case "":
-		break;  // annotation not set
+	case "": // annotation not set
 	default:
 		logrus.Errorf("Unknown service health status '%v' ignored", healthStr)
 	}

--- a/pkg/daemon/struct.go
+++ b/pkg/daemon/struct.go
@@ -213,6 +213,10 @@ func (p *Pod) GetServiceHealth(n string, defaultVal string) string {
 	case consulApi.HealthPassing:
 	case consulApi.HealthWarning:
 		return healthStr
+	case "":
+		break;  // annotation not set
+	default:
+		logrus.Errorf("Unknown service health status '%v' ignored", healthStr)
 	}
 	return defaultVal
 }

--- a/pkg/daemon/struct.go
+++ b/pkg/daemon/struct.go
@@ -35,7 +35,7 @@ var (
 	ConsulServiceCheckTTL     = "katalog-sync.wish.com/service-check-ttl" // TTL for the service checks we put in consul
 	ContainerExclusion        = "katalog-sync.wish.com/container-exclude" // comma-separated list of containers to exclude from ready check
 
-	// Meta keys that are used as per-service flags
+	// metadata keys in Consul (not k8s annotations) that are used as per-service flags
 	MetaAlwaysHealthy = "_always_healthy"  // always mark service as healthy in Consul
 )
 


### PR DESCRIPTION
The main motivation is to mark a service as health regardless of its readiness status, this is useful for cases where we just need a DNS name.