### PR TITLE
correct the clusterrole

### DIFF
--- a/config/daemonset.yaml
+++ b/config/daemonset.yaml
@@ -36,6 +36,13 @@ rules:
   - pods/status
   verbs:
   - patch
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  verbs:
+  - list
+  - get
 ---
 apiVersion: apps/v1
 kind: DaemonSet


### PR DESCRIPTION
katalog-sync-daemon needs the permission to get all pods from k8s api.