### PR TITLE
fix bug where health annotation not used during update

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -411,7 +411,9 @@ func (d *Daemon) syncConsul() error {
 				// only call update if we are past halflife of last update
 				if pod.SyncStatuses.GetStatus(serviceName).LastUpdated.IsZero() || time.Now().Sub(pod.SyncStatuses.GetStatus(serviceName).LastUpdated) >= (pod.CheckTTL/2) {
 					// If the service already exists, just update the check
-					pod.SyncStatuses.GetStatus(serviceName).SetError(d.consulClient.Agent().UpdateTTL(pod.GetServiceID(serviceName), string(notesB), status))
+					pod.SyncStatuses.GetStatus(serviceName).SetError(
+						d.consulClient.Agent().UpdateTTL(
+							pod.GetServiceID(serviceName), string(notesB), pod.GetServiceHealth(serviceName, status)))
 				}
 			} else {
 				// Define the base metadata that katalog-sync requires


### PR DESCRIPTION
 #47 only use the annotation when register the service, not when update the service. 