### PR TITLE
fix duplicated service instances issue

### DIFF
--- a/config/daemonset.yaml
+++ b/config/daemonset.yaml
@@ -73,6 +73,11 @@ spec:
         name: katalog-sync-daemon
       hostNetwork: true
       terminationGracePeriodSeconds: 5
+      env:
+      - name: NODE_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: spec.nodeName
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists


### PR DESCRIPTION
Every katalog-sync pod will register the service through the local consul-client, and then the pod which has annotation "katalog-sync.wish.com/service-names" will be registered repeatedly.
![Screen Shot 2021-04-28 at 3 32 35 PM](https://user-images.githubusercontent.com/72126801/116364950-5654d580-a837-11eb-9078-1563153425f4.png)

Katalog-sync should only sync the pod which is located on the same node.