### PR TITLE
WIP fix for pods synced but not ready

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -379,6 +379,7 @@ func (d *Daemon) waitPod(pod *Pod) {
 			pod.HandleReadinessGate()
 			return
 		}
+		time.Sleep(time.Second) // TODO; exponential backoff
 	}
 }
 


### PR DESCRIPTION
As of now when a pod is synced but not ready katalog-sync will spin as fast as it can to recheck (no sleep). This adds a sleep in the event it wasn't ready to avoid burning all the CPU.

TODO: Another thing I noticed is the check here only ensures that the service was synced to consul not that the readiness has been synced -- which we probably want to check as well.