### PR TITLE
Add non-root user to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,3 +20,8 @@ FROM golang:alpine
 
 COPY --from=builder /go/src/github.com/wish/katalog-sync/cmd/katalog-sync-daemon/katalog-sync-daemon /bin/katalog-sync-daemon
 COPY --from=builder /go/src/github.com/wish/katalog-sync/cmd/katalog-sync-sidecar/katalog-sync-sidecar /bin/katalog-sync-sidecar
+
+ARG USER=katalog-sync
+ENV HOME /home/$USER
+RUN addgroup -S $USER && adduser -S -G $USER -u 12345 $USER
+USER $USER


### PR DESCRIPTION
## context

hey there, we'd like to run this Docker image as a non-root user, as a security best practice. going through testing right now. thankfully it's pretty straightforward to add a user & switch to it in alpine-based images. thanks for katalog-sync!

## changes

- add a user `katalog-sync` with arbitrary uid `12345` 
- switch to it in the Dockerfile so we don't have to run as root